### PR TITLE
fix config reference

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,3 +1,3 @@
 from nginx
 
-COPY ./scs-commerce.nginx.now.conf /etc/nginx/conf.d/default.conf
+COPY ./scs-commerce.nginx.conf /etc/nginx/conf.d/default.conf


### PR DESCRIPTION
discovered while following the setup instructions at https://scs-commerce.github.io

```
Step 2/2 : COPY ./scs-commerce.nginx.now.conf /etc/nginx/conf.d/default.conf
ERROR: Service 'integration' failed to build: COPY failed: stat /var/lib/docker/tmp/docker-builder528559945/scs-commerce.nginx.now.conf: no such file or directory
```